### PR TITLE
Enable alarm when time is changed

### DIFF
--- a/app/src/main/java/me/jfenn/alarmio/adapters/AlarmsAdapter.kt
+++ b/app/src/main/java/me/jfenn/alarmio/adapters/AlarmsAdapter.kt
@@ -291,6 +291,7 @@ class AlarmsAdapter(private val alarmio: Alarmio, private val recycler: Recycler
                             alarm.time.set(Calendar.HOUR_OF_DAY, view.hourOfDay)
                             alarm.time.set(Calendar.MINUTE, view.minute)
                             alarm.setTime(alarmio, alarmManager, alarm.time.timeInMillis)
+                            alarm.setEnabled(alarmio, alarmManager, true);
 
                             notifyItemChanged(holder.adapterPosition)
                         }

--- a/app/src/main/java/me/jfenn/alarmio/data/AlarmData.java
+++ b/app/src/main/java/me/jfenn/alarmio/data/AlarmData.java
@@ -125,7 +125,7 @@ public class AlarmData implements Parcelable {
     }
 
     /**
-     * Change the scheduled alarm time,
+     * Change the scheduled alarm time.
      *
      * @param context       An active context instance.
      * @param manager       An AlarmManager to schedule the alarm on.


### PR DESCRIPTION
Fixes #88

I'm not entirely sure if it is OK to pass 'alarmio' for the 'context' parameter: at AlarmAdapter.kt:277 'alarmio' is used as well, but in HomeFragment.java:257 a different context is passed. I'm not familiar enough with Android to understand what the relevance of that is.

