### PR TITLE
Use volume float when possible

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
           KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
           KEYSTORE_ALIAS_PASSWORD: ${{ secrets.KEYSTORE_ALIAS_PASSWORD }}
           CI: true
-        run: /gradlew assembleOss
+        run: ./gradlew assembleOss
       - uses: Shopify/upload-to-release@master
         name: Upload APK to Release
         with:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 Alarmio
 [![Build Status](https://github.com/fennifith/Alarmio/workflows/Gradle%20Build/badge.svg)](https://github.com/fennifith/Alarmio/actions)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/e214b14f27464ce39a24539fc0ca27a5)](https://www.codacy.com/app/fennifith/Alarmio?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=fennifith/Alarmio&amp;utm_campaign=Badge_Grade)
-[![Discord](https://img.shields.io/discord/514625116706177035.svg?logo=discord&colorB=7289da)](https://discord.gg/kgqJ5hM)
+[![Discord](https://img.shields.io/discord/514625116706177035.svg?logo=discord&colorB=7289da)](https://discord.jfenn.me/)
 [![Liberapay](https://img.shields.io/badge/liberapay-donate-yellow.svg?logo=liberapay)](https://jfenn.me/links/liberapay)
 =======
 

--- a/app/src/main/java/me/jfenn/alarmio/Alarmio.java
+++ b/app/src/main/java/me/jfenn/alarmio/Alarmio.java
@@ -434,6 +434,15 @@ public class Alarmio extends Application implements Player.EventListener {
     }
 
     /**
+     * Sets the player volume to the given float.
+     *
+     * @param volume            The volume between 0 and 1
+     */
+    public void setStreamVolume(float volume) {
+        player.setVolume(volume);
+    }
+
+    /**
      * Determine if the passed url matches the stream that is currently playing.
      *
      * @param url           The URL to match the current stream to.

--- a/app/src/main/java/me/jfenn/alarmio/activities/AlarmActivity.java
+++ b/app/src/main/java/me/jfenn/alarmio/activities/AlarmActivity.java
@@ -119,7 +119,7 @@ public class AlarmActivity extends AestheticActivity implements SlideActionListe
 
         date.setText(FormatUtils.format(new Date(), FormatUtils.FORMAT_DATE + ", " + FormatUtils.getShortFormat(this)));
 
-        if (!sound.setVolumeSupported()) {
+        if (!sound.isSetVolumeSupported()) {
             // Use the backup method if it is not supported
 
             audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
@@ -165,7 +165,7 @@ public class AlarmActivity extends AestheticActivity implements SlideActionListe
                     getWindow().setAttributes(params);
                     getWindow().addFlags(WindowManager.LayoutParams.FLAGS_CHANGED);
 
-                    if (sound.setVolumeSupported()) {
+                    if (sound.isSetVolumeSupported()) {
                         float newVolume = Math.min(1f, slowWakeProgress);
 
                         sound.setVolume(alarmio, newVolume);
@@ -221,7 +221,7 @@ public class AlarmActivity extends AestheticActivity implements SlideActionListe
         if (sound != null && sound.isPlaying(alarmio)) {
             sound.stop(alarmio);
 
-            if (isSlowWake && !sound.setVolumeSupported()) {
+            if (isSlowWake && !sound.isSetVolumeSupported()) {
                 audioManager.setStreamVolume(AudioManager.STREAM_ALARM, originalVolume, 0);
             }
         }

--- a/app/src/main/java/me/jfenn/alarmio/activities/AlarmActivity.java
+++ b/app/src/main/java/me/jfenn/alarmio/activities/AlarmActivity.java
@@ -119,18 +119,22 @@ public class AlarmActivity extends AestheticActivity implements SlideActionListe
 
         date.setText(FormatUtils.format(new Date(), FormatUtils.FORMAT_DATE + ", " + FormatUtils.getShortFormat(this)));
 
-        audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
-        originalVolume = audioManager.getStreamVolume(AudioManager.STREAM_ALARM);
-        if (isSlowWake) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                minVolume = audioManager.getStreamMinVolume(AudioManager.STREAM_ALARM);
-            } else {
-                minVolume = 0;
-            }
-            volumeRange = originalVolume - minVolume;
-            currentVolume = minVolume;
+        if (!sound.setVolumeSupported()) {
+            // Use the backup method if it is not supported
 
-            audioManager.setStreamVolume(AudioManager.STREAM_ALARM, minVolume, 0);
+            audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+            originalVolume = audioManager.getStreamVolume(AudioManager.STREAM_ALARM);
+            if (isSlowWake) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    minVolume = audioManager.getStreamMinVolume(AudioManager.STREAM_ALARM);
+                } else {
+                    minVolume = 0;
+                }
+                volumeRange = originalVolume - minVolume;
+                currentVolume = minVolume;
+
+                audioManager.setStreamVolume(AudioManager.STREAM_ALARM, minVolume, 0);
+            }
         }
 
         vibrator = (Vibrator) getSystemService(Context.VIBRATOR_SERVICE);
@@ -161,7 +165,12 @@ public class AlarmActivity extends AestheticActivity implements SlideActionListe
                     getWindow().setAttributes(params);
                     getWindow().addFlags(WindowManager.LayoutParams.FLAGS_CHANGED);
 
-                    if (currentVolume < originalVolume) {
+                    if (sound.setVolumeSupported()) {
+                        float newVolume = Math.min(1f, slowWakeProgress);
+
+                        sound.setVolume(alarmio, newVolume);
+                    } else if (currentVolume < originalVolume) {
+                        // Backup volume setting behavior
                         int newVolume = minVolume + (int) Math.min(originalVolume, slowWakeProgress * volumeRange);
                         if (newVolume != currentVolume) {
                             audioManager.setStreamVolume(audioManager.STREAM_ALARM, newVolume, 0);
@@ -212,7 +221,7 @@ public class AlarmActivity extends AestheticActivity implements SlideActionListe
         if (sound != null && sound.isPlaying(alarmio)) {
             sound.stop(alarmio);
 
-            if (isSlowWake) {
+            if (isSlowWake && !sound.setVolumeSupported()) {
                 audioManager.setStreamVolume(AudioManager.STREAM_ALARM, originalVolume, 0);
             }
         }

--- a/app/src/main/java/me/jfenn/alarmio/data/SoundData.java
+++ b/app/src/main/java/me/jfenn/alarmio/data/SoundData.java
@@ -125,6 +125,32 @@ public class SoundData {
     }
 
     /**
+     * Sets the player volume to the given float.
+     *
+     * @param alarmio           The active Application instance.
+     * @param volume            The volume between 0 and 1
+     */
+    public void setVolume(Alarmio alarmio, float volume) {
+        if (ringtone != null)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                ringtone.setVolume(volume);
+            } else {
+                // Not possible
+                throw new IllegalArgumentException("Setting the ringtone volume on a device older than Android P");
+            }
+        else alarmio.setStreamVolume(volume);
+    }
+
+    /**
+     * Is the setVolume method supported on this version of Android
+     *
+     * @return true if supported
+     */
+    public boolean setVolumeSupported() {
+        return ringtone == null || Build.VERSION.SDK_INT >= Build.VERSION_CODES.P;
+    }
+
+    /**
      * Returns an identifier string that can be used to recreate this
      * SoundDate class.
      *

--- a/app/src/main/java/me/jfenn/alarmio/data/SoundData.java
+++ b/app/src/main/java/me/jfenn/alarmio/data/SoundData.java
@@ -136,7 +136,7 @@ public class SoundData {
                 ringtone.setVolume(volume);
             } else {
                 // Not possible
-                throw new IllegalArgumentException("Setting the ringtone volume on a device older than Android P");
+                throw new IllegalArgumentException("Attempted to set the ringtone volume on a device older than Android P.");
             }
         else alarmio.setStreamVolume(volume);
     }
@@ -146,7 +146,7 @@ public class SoundData {
      *
      * @return true if supported
      */
-    public boolean setVolumeSupported() {
+    public boolean isSetVolumeSupported() {
         return ringtone == null || Build.VERSION.SDK_INT >= Build.VERSION_CODES.P;
     }
 


### PR DESCRIPTION
In newer Android versions, the actual volume is limited to a small (7 on OnePlus) discrete number of levels. A float will produce a much smoother transition.

Resolves https://github.com/fennifith/Alarmio/issues/84