### PR TITLE
Options fix + Volume Option

### DIFF
--- a/app/src/main/java/me/jfenn/alarmio/activities/AlarmActivity.java
+++ b/app/src/main/java/me/jfenn/alarmio/activities/AlarmActivity.java
@@ -170,7 +170,7 @@ public class AlarmActivity extends AestheticActivity implements SlideActionListe
                     getWindow().addFlags(WindowManager.LayoutParams.FLAGS_CHANGED);
 
                     if (sound != null && sound.isSetVolumeSupported()) {
-                        float newVolume = Math.min(1f, slowWakeProgress);
+                        float newVolume = Math.min(1f, slowWakeProgress) * (PreferenceData.MANUAL_VOLUME_SETTING.<Integer>getValue(AlarmActivity.this) / 100f);
 
                         sound.setVolume(alarmio, newVolume);
                     } else if (currentVolume < originalVolume) {

--- a/app/src/main/java/me/jfenn/alarmio/data/PreferenceData.java
+++ b/app/src/main/java/me/jfenn/alarmio/data/PreferenceData.java
@@ -23,6 +23,7 @@ public enum PreferenceData {
     SLEEP_REMINDER_TIME(25200000L), //milliseconds
     SLOW_WAKE_UP(true),
     SLOW_WAKE_UP_TIME(300000L), //milliseconds
+    MANUAL_VOLUME_SETTING(100),
     ALARM_NAME("%d/ALARM_NAME", null),
     ALARM_TIME("%d/ALARM_TIME", (long) 0),
     ALARM_ENABLED("%d/ALARM_ENABLED", true),

--- a/app/src/main/java/me/jfenn/alarmio/data/preference/BooleanPreferenceData.kt
+++ b/app/src/main/java/me/jfenn/alarmio/data/preference/BooleanPreferenceData.kt
@@ -30,7 +30,7 @@ class BooleanPreferenceData(private val preference: PreferenceData, @StringRes p
         holder.description.setText(description)
         holder.toggle.setOnCheckedChangeListener(null)
 
-        holder.toggle.isChecked = preference.getValue(holder.itemView.context, false) ?: false
+        holder.toggle.isChecked = preference.getValue(holder.itemView.context) ?: false
         holder.toggle.setOnCheckedChangeListener { compoundButton, b -> preference.setValue(compoundButton.context, b) }
 
         Aesthetic.get()

--- a/app/src/main/java/me/jfenn/alarmio/data/preference/SliderPreferenceData.kt
+++ b/app/src/main/java/me/jfenn/alarmio/data/preference/SliderPreferenceData.kt
@@ -1,0 +1,68 @@
+package me.jfenn.alarmio.data.preference
+
+import android.annotation.SuppressLint
+import android.graphics.Color
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.SeekBar
+import android.widget.TextView
+import androidx.annotation.StringRes
+import androidx.appcompat.widget.SwitchCompat
+import androidx.core.widget.CompoundButtonCompat
+import com.afollestad.aesthetic.Aesthetic
+import me.jfenn.alarmio.R
+import me.jfenn.alarmio.data.PreferenceData
+
+/**
+ * Allow the user to choose from a simple boolean
+ * using a switch item view.
+ */
+class SliderPreferenceData(private val preference: PreferenceData, private val maximum: Int, @StringRes private val title: Int, @StringRes private val description: Int) : BasePreferenceData<SliderPreferenceData.ViewHolder>() {
+
+    override fun getViewHolder(inflater: LayoutInflater, parent: ViewGroup): BasePreferenceData.ViewHolder {
+        return ViewHolder(inflater.inflate(R.layout.item_preference_slider, parent, false))
+    }
+
+    @SuppressLint("CheckResult")
+    override fun bindViewHolder(holder: ViewHolder) {
+        holder.title.setText(title)
+        holder.description.setText(description)
+        holder.sliderChoice.max = maximum
+        holder.sliderChoice.progress = preference.getValue(holder.context)
+        holder.sliderChoiceView.text = preference.getValue<Int>(holder.context).toString()
+
+        holder.sliderChoice.onProgressChanged { _, progress, _ ->
+            preference.setValue(holder.context, progress)
+            holder.sliderChoiceView.text = progress.toString()
+        }
+    }
+
+    /**
+     * Holds child views of the current item.
+     */
+    inner class ViewHolder(v: View) : BasePreferenceData.ViewHolder(v) {
+        val title: TextView = v.findViewById(R.id.title)
+        val description: TextView = v.findViewById(R.id.description)
+        val sliderChoice: SeekBar = v.findViewById(R.id.sliderChoice)
+        val sliderChoiceView: TextView = v.findViewById(R.id.sliderChoiceView)
+    }
+
+    private fun SeekBar.onProgressChanged(onProgressChanged: (seekBar: SeekBar?, progress: Int, fromUser: Boolean) -> Unit) {
+        this.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+            override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
+                onProgressChanged.invoke(seekBar, progress, fromUser)
+            }
+
+            override fun onStartTrackingTouch(seekBar: SeekBar?) {
+            }
+
+            override fun onStopTrackingTouch(seekBar: SeekBar?) {
+            }
+        })
+    }
+
+}

--- a/app/src/main/java/me/jfenn/alarmio/data/preference/StringPreferenceData.kt
+++ b/app/src/main/java/me/jfenn/alarmio/data/preference/StringPreferenceData.kt
@@ -1,0 +1,64 @@
+package me.jfenn.alarmio.data.preference
+
+import android.annotation.SuppressLint
+import android.content.res.ColorStateList
+import android.graphics.Color
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.TextView
+import androidx.annotation.StringRes
+import androidx.appcompat.widget.SwitchCompat
+import androidx.core.widget.CompoundButtonCompat
+import com.afollestad.aesthetic.Aesthetic
+import me.jfenn.alarmio.R
+import me.jfenn.alarmio.data.PreferenceData
+
+/**
+ * Allow the user to choose from a simple boolean
+ * using a switch item view.
+ */
+class StringPreferenceData(private val preference: PreferenceData, @StringRes private val title: Int, @StringRes private val description: Int) : BasePreferenceData<StringPreferenceData.ViewHolder>() {
+
+    override fun getViewHolder(inflater: LayoutInflater, parent: ViewGroup): BasePreferenceData.ViewHolder {
+        return ViewHolder(inflater.inflate(R.layout.item_preference_string, parent, false))
+    }
+
+    @SuppressLint("CheckResult")
+    override fun bindViewHolder(holder: ViewHolder) {
+        holder.title.setText(title)
+        holder.description.setText(description)
+        holder.textChoice.setText(preference.getValue<String>(holder.context))
+        holder.textChoice.afterTextChanged { editable -> preference.setValue(holder.context, editable.toString()) }
+
+        // Scroll to it when focused
+
+    }
+
+    /**
+     * Holds child views of the current item.
+     */
+    inner class ViewHolder(v: View) : BasePreferenceData.ViewHolder(v) {
+        val title: TextView = v.findViewById(R.id.title)
+        val description: TextView = v.findViewById(R.id.description)
+        val textChoice: EditText = v.findViewById(R.id.textChoice)
+    }
+
+    fun EditText.afterTextChanged(afterTextChanged: (Editable?) -> Unit) {
+        this.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+            }
+
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+            }
+
+            override fun afterTextChanged(editable: Editable?) {
+                afterTextChanged.invoke(editable)
+            }
+        })
+    }
+
+}

--- a/app/src/main/java/me/jfenn/alarmio/data/preference/StringPreferenceData.kt
+++ b/app/src/main/java/me/jfenn/alarmio/data/preference/StringPreferenceData.kt
@@ -33,9 +33,6 @@ class StringPreferenceData(private val preference: PreferenceData, @StringRes pr
         holder.description.setText(description)
         holder.textChoice.setText(preference.getValue<String>(holder.context))
         holder.textChoice.afterTextChanged { editable -> preference.setValue(holder.context, editable.toString()) }
-
-        // Scroll to it when focused
-
     }
 
     /**
@@ -47,7 +44,7 @@ class StringPreferenceData(private val preference: PreferenceData, @StringRes pr
         val textChoice: EditText = v.findViewById(R.id.textChoice)
     }
 
-    fun EditText.afterTextChanged(afterTextChanged: (Editable?) -> Unit) {
+    private fun EditText.afterTextChanged(afterTextChanged: (Editable?) -> Unit) {
         this.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
             }

--- a/app/src/main/java/me/jfenn/alarmio/fragments/SettingsFragment.java
+++ b/app/src/main/java/me/jfenn/alarmio/fragments/SettingsFragment.java
@@ -33,6 +33,7 @@ import me.jfenn.alarmio.data.preference.BooleanPreferenceData;
 import me.jfenn.alarmio.data.preference.CustomPreferenceData;
 import me.jfenn.alarmio.data.preference.ImageFilePreferenceData;
 import me.jfenn.alarmio.data.preference.RingtonePreferenceData;
+import me.jfenn.alarmio.data.preference.SliderPreferenceData;
 import me.jfenn.alarmio.data.preference.ThemePreferenceData;
 import me.jfenn.alarmio.data.preference.TimePreferenceData;
 import me.jfenn.alarmio.data.preference.TimeZonesPreferenceData;
@@ -65,7 +66,8 @@ public class SettingsFragment extends BasePagerFragment implements Consumer {
                 new BooleanPreferenceData(PreferenceData.SLEEP_REMINDER, R.string.title_sleep_reminder, R.string.desc_sleep_reminder),
                 new TimePreferenceData(PreferenceData.SLEEP_REMINDER_TIME, R.string.title_sleep_reminder_time),
                 new BooleanPreferenceData(PreferenceData.SLOW_WAKE_UP, R.string.title_slow_wake_up, R.string.desc_slow_wake_up),
-                new TimePreferenceData(PreferenceData.SLOW_WAKE_UP_TIME, R.string.title_slow_wake_up_time)
+                new TimePreferenceData(PreferenceData.SLOW_WAKE_UP_TIME, R.string.title_slow_wake_up_time),
+                new SliderPreferenceData(PreferenceData.MANUAL_VOLUME_SETTING, 100, R.string.title_manual_volume, R.string.desc_manual_volume)
         ));
 
         if (Build.VERSION.SDK_INT >= 23) {

--- a/app/src/main/res/layout/item_preference_slider.xml
+++ b/app/src/main/res/layout/item_preference_slider.xml
@@ -23,13 +23,25 @@
             android:textSize="16sp"
             tools:text="Title" />
 
-        <!-- Cursor should be visible: https://stackoverflow.com/a/9165217-->
-        <EditText
-            android:id="@+id/textChoice"
+        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textCursorDrawable="@null"
-            android:inputType="textNoSuggestions" />
+            android:orientation="horizontal" >
+
+            <SeekBar
+                android:id="@+id/sliderChoice"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+            <TextView
+                android:id="@+id/sliderChoiceView"
+                android:layout_width="80dp"
+                android:layout_height="wrap_content"
+                android:text="sssss"
+                android:layout_weight="1" />
+
+        </LinearLayout>
 
         <TextView
             android:id="@+id/description"

--- a/app/src/main/res/layout/item_preference_string.xml
+++ b/app/src/main/res/layout/item_preference_string.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:paddingBottom="18dp"
+    android:paddingEnd="16dp"
+    android:paddingStart="16dp"
+    android:paddingTop="18dp">
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="?android:textColorPrimary"
+            android:textSize="16sp"
+            tools:text="Title" />
+
+        <!-- Cursor should be visible: https://stackoverflow.com/a/9165217-->
+        <EditText
+            android:id="@+id/textChoice"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textCursorDrawable="@null"
+            android:inputType="textNoSuggestions" />
+
+        <TextView
+            android:id="@+id/description"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="?android:textColorSecondary"
+            android:textSize="14sp"
+            tools:text="Description" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -89,4 +89,6 @@
     <!-- untranslated strings -->
     <string name="info_background_permissions_title">System Alerts / Background Permissions</string>
     <string name="info_background_permissions_body">Newer versions of Android are becoming increasingly unreliable at starting apps from the background without user interaction; with the introduction of Doze/App Standby in Android 6.0, the requirements for an app to be started are ambiguous and often device-specific.\n\nAs such, while it is not always a requirement for this app to function, it is highly recommended that you grant the System Overlays permission on the next page. This will grant Alarmio an exemption from Android\'s usual requirements for starting an app without user interaction, and allow it to function much more reliably.</string>
+    <string name="title_manual_volume">Manual Alarm Volume</string>
+    <string name="desc_manual_volume">Your device\'s alarm volume will be multiplied by this number. This will give your more precise control as some devices limit volume to device fixed number of steps.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -85,4 +85,6 @@
     <string name="day_saturday_abbr">S</string>
     <string name="info_background_permissions_title">System Alerts / Background Permissions</string>
     <string name="info_background_permissions_body">Newer versions of Android are becoming increasingly unreliable at starting apps from the background without user interaction; with the introduction of Doze/App Standby in Android 6.0, the requirements for an app to be started are ambiguous and often device-specific.\n\nAs such, while it is not always a requirement for this app to function, it is highly recommended that you grant the System Overlays permission on the next page. This will grant Alarmio an exemption from Android\'s usual requirements for starting an app without user interaction, and allow it to function much more reliably.</string>
+    <string name="title_manual_volume">Manual Alarm Volume</string>
+    <string name="desc_manual_volume">Your device\'s alarm volume will be multiplied by this number. This will give your more precise control as some devices limit volume to device fixed number of steps.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -85,4 +85,6 @@
     <string name="day_saturday_abbr">S</string>
     <string name="info_background_permissions_title">System Alerts / Background Permissions</string>
     <string name="info_background_permissions_body">Newer versions of Android are becoming increasingly unreliable at starting apps from the background without user interaction; with the introduction of Doze/App Standby in Android 6.0, the requirements for an app to be started are ambiguous and often device-specific.\n\nAs such, while it is not always a requirement for this app to function, it is highly recommended that you grant the System Overlays permission on the next page. This will grant Alarmio an exemption from Android\'s usual requirements for starting an app without user interaction, and allow it to function much more reliably.</string>
+    <string name="title_manual_volume">Manual Alarm Volume</string>
+    <string name="desc_manual_volume">Your device\'s alarm volume will be multiplied by this number. This will give your more precise control as some devices limit volume to device fixed number of steps.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -88,4 +88,6 @@
     <string name="day_saturday_abbr">S</string>
     <string name="info_background_permissions_title">System Alerts / Background Permissions</string>
     <string name="info_background_permissions_body">Newer versions of Android are becoming increasingly unreliable at starting apps from the background without user interaction; with the introduction of Doze/App Standby in Android 6.0, the requirements for an app to be started are ambiguous and often device-specific.\n\nAs such, while it is not always a requirement for this app to function, it is highly recommended that you grant the System Overlays permission on the next page. This will grant Alarmio an exemption from Android\'s usual requirements for starting an app without user interaction, and allow it to function much more reliably.</string>
+    <string name="title_manual_volume">Manual Alarm Volume</string>
+    <string name="desc_manual_volume">Your device\'s alarm volume will be multiplied by this number. This will give your more precise control as some devices limit volume to device fixed number of steps.</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -87,4 +87,7 @@
     <!-- untranslated strings -->
     <string name="info_background_permissions_title">System Alerts / Background Permissions</string>
     <string name="info_background_permissions_body">Newer versions of Android are becoming increasingly unreliable at starting apps from the background without user interaction; with the introduction of Doze/App Standby in Android 6.0, the requirements for an app to be started are ambiguous and often device-specific.\n\nAs such, while it is not always a requirement for this app to function, it is highly recommended that you grant the System Overlays permission on the next page. This will grant Alarmio an exemption from Android\'s usual requirements for starting an app without user interaction, and allow it to function much more reliably.</string>
+    <string name="title_manual_volume">Manual Alarm Volume</string>
+    <string name="desc_manual_volume">Your device\'s alarm volume will be multiplied by this number. This will give your more precise control as some devices limit volume to device fixed number of steps.</string>
+
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -85,4 +85,7 @@
     <string name="day_saturday_abbr">S</string>
     <string name="info_background_permissions_title">System Alerts / Background Permissions</string>
     <string name="info_background_permissions_body">Newer versions of Android are becoming increasingly unreliable at starting apps from the background without user interaction; with the introduction of Doze/App Standby in Android 6.0, the requirements for an app to be started are ambiguous and often device-specific.\n\nAs such, while it is not always a requirement for this app to function, it is highly recommended that you grant the System Overlays permission on the next page. This will grant Alarmio an exemption from Android\'s usual requirements for starting an app without user interaction, and allow it to function much more reliably.</string>
+    <string name="title_manual_volume">Manual Alarm Volume</string>
+    <string name="desc_manual_volume">Your device\'s alarm volume will be multiplied by this number. This will give your more precise control as some devices limit volume to device fixed number of steps.</string>
+
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -87,4 +87,8 @@
   <!-- untranslated strings -->
   <string name="info_background_permissions_title">System Alerts / Background Permissions</string>
   <string name="info_background_permissions_body">Newer versions of Android are becoming increasingly unreliable at starting apps from the background without user interaction; with the introduction of Doze/App Standby in Android 6.0, the requirements for an app to be started are ambiguous and often device-specific.\n\nAs such, while it is not always a requirement for this app to function, it is highly recommended that you grant the System Overlays permission on the next page. This will grant Alarmio an exemption from Android\'s usual requirements for starting an app without user interaction, and allow it to function much more reliably.</string>
+
+  <string name="title_manual_volume">Manual Alarm Volume</string>
+  <string name="desc_manual_volume">Your device\'s alarm volume will be multiplied by this number. This will give your more precise control as some devices limit volume to device fixed number of steps.</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,9 @@
     <string name="msg_battery_optimizations_switch_enable">Turn on the switch next to \"Alarmio\". You may need to scroll down… a lot.</string>
     <string name="title_ignore_battery_optimizations">Ignore Battery Optimizations</string>
 
+    <string name="title_manual_volume">Manual Alarm Volume</string>
+    <string name="desc_manual_volume">Your device\'s alarm volume will be multiplied by this number. This will give your more precise control as some devices limit volume to device fixed number of steps.</string>
+
     <string name="day_sunday_abbr">S</string>
     <string name="day_monday_abbr">M</string>
     <string name="day_tuesday_abbr">T</string>


### PR DESCRIPTION
- Fixes boolean options not using default option
- Adds slider alarm volume option that will be multiplied by the system alarm volume*
- Added new String volume type (I used it in [my fork](https://github.com/ajayyy/AlarmioRemote/), but I figured it wouldn't be a bad idea to have in the main repo in case it is needed)

* If you think that is too confusing, it can be changed to replace the system alarm volume. The main goal is to sidestep the system's limitation of a fixed number of volume steps. Volume 1 on many phones is still very loud.

It's crazy that you have to copy strings into all translations if they aren't translations yet. Also, I have not used Kotlin before, but it seems really nice. I'll have to try it on some of my own projects.

My remote dismissing fork is not merged into the master because I feel it would add too much clutter for most users and it is done in a very hacky way.