### PR TITLE
Fix a NPE of AudioManager

### DIFF
--- a/app/src/main/java/me/jfenn/alarmio/activities/AlarmActivity.java
+++ b/app/src/main/java/me/jfenn/alarmio/activities/AlarmActivity.java
@@ -225,7 +225,7 @@ public class AlarmActivity extends AestheticActivity implements SlideActionListe
         if (sound != null && sound.isPlaying(alarmio)) {
             sound.stop(alarmio);
 
-            if (isSlowWake && !sound.isSetVolumeSupported()) {
+            if (audioManager != null && isSlowWake && !sound.isSetVolumeSupported()) {
                 audioManager.setStreamVolume(AudioManager.STREAM_ALARM, originalVolume, 0);
             }
         }


### PR DESCRIPTION
The alarm was ringing and I tried to exit the UI, and then...

```
shell@ZM1:/ $ getprop | grep ro.build
[ro.build.characteristics]: [default]
[ro.build.date.utc]: [1446646774]
[ro.build.date]: [Wed Nov 4 22:19:34 CST 2015]
[ro.build.description]: [M560_10CN-user 5.1 LMY47D 10CN_5_18H release-keys]
[ro.build.display.id]: [10CN_5_18H]
[ro.build.fingerprint]: [InFocus/M560_10CN/ZM1:5.1/LMY47D/10CN_5_18H:user/release-keys]
[ro.build.flavor]: [ZM1_10CN_FIH-user]
[ro.build.host]: [NJ-SW-UBUNTU-S7]
[ro.build.id]: [LMY47D]
[ro.build.product]: [ZM1]
[ro.build.tags]: [release-keys]
[ro.build.type]: [user]
[ro.build.user]: [foxconn]
[ro.build.version.all_codenames]: [REL]
[ro.build.version.codename]: [REL]
[ro.build.version.incremental]: [10CN_5_18H]
[ro.build.version.release]: [5.1]
[ro.build.version.sdk]: [22]
```