### PR TITLE
Fix crash when adding a timer and going back to the overview

### DIFF
--- a/app/src/main/java/me/jfenn/alarmio/adapters/AlarmsAdapter.kt
+++ b/app/src/main/java/me/jfenn/alarmio/adapters/AlarmsAdapter.kt
@@ -447,8 +447,8 @@ class AlarmsAdapter(private val alarmio: Alarmio, private val recycler: Recycler
                 }
 
                 override fun afterTextChanged(editable: Editable) {
-                    alarms[adapterPosition].setName(alarmio, editable.toString())
-
+                    val alarmPosition = adapterPosition - alarmio.timers.size
+                    alarms[alarmPosition].setName(alarmio, editable.toString())
                 }
             })
         }


### PR DESCRIPTION
The timers have to be taken into account when calculating the position.
This always causes the app to crash when one has alarms set and just created a timer.